### PR TITLE
option to output translate coding scores as parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,24 @@ A reference proteome *must* be supplied as the first argument.
 sencha translate reference-proteome.fa.gz *.fastq.gz > coding_peptides.fasta
 ```
 
-#### Save the "coding scores" to a csv
+#### Save the "coding scores" to a csv or parquet file
 
 The "coding score" of each read is calculated by translating each read in six
 frames, then is calculatating the
 [Jaccard index](https://en.wikipedia.org/wiki/Jaccard_index) between any of the
 six translated frames of the read and the peptide database. The final coding
 score is the maximum Jaccard index across all reading frames. If you'd like to
-see the coding scores for all reads, use the `--csv` flag.
+see the coding scores for all reads, use the `--csv` flag or `--parquet` flag.
 
+csv:
 ```
 sencha translate --csv coding_scores.csv reference-proteome.fa.gz *.fastq.gz > coding_peptides.fasta
 ```
 
+parquet:
+```
+sencha translate --parquet coding_scores.parquet reference-proteome.fa.gz *.fastq.gz > coding_peptides.fasta
+```
 
 #### Save the coding nucleotides to a fasta
 

--- a/sencha/create_save_summary.py
+++ b/sencha/create_save_summary.py
@@ -15,6 +15,7 @@ class CreateSaveSummary:
         self,
         filenames,
         csv,
+        parquet,
         json_summary,
         peptide_bloom_filter_filename,
         alphabet,
@@ -23,6 +24,7 @@ class CreateSaveSummary:
     ):
         self.filenames = filenames
         self.csv = csv
+        self.parquet = parquet
         self.json_summary = json_summary
         self.peptide_bloom_filter_filename = peptide_bloom_filter_filename
         self.alphabet = alphabet
@@ -33,6 +35,11 @@ class CreateSaveSummary:
         if self.csv:
             logger.info("Writing coding scores of reads to {}".format(self.csv))
             coding_scores.to_csv(self.csv, index=False)
+
+    def maybe_write_parquet(self, coding_scores):
+        if self.parquet:
+            logger.info("Writing coding scores of reads to {}".format(self.parquet))
+            coding_scores.to_parquet(self.parquet, index=False)
 
     def make_empty_coding_categories(self):
         coding_categories = dict.fromkeys(PROTEIN_CODING_CATEGORIES.values(), 0)

--- a/sencha/translate.py
+++ b/sencha/translate.py
@@ -450,6 +450,12 @@ class Translate:
     help="Name of csv file to write with all sequence reads and " "their coding scores",
 )
 @click.option(
+    "--parquet",
+    default=False,
+    help="Name of parquet file to write with all sequence reads and "
+    "their coding scores",
+)
+@click.option(
     "--json-summary",
     default=False,
     help="Name of json file to write summarization of coding/"
@@ -501,6 +507,7 @@ def cli(
     jaccard_threshold=None,
     alphabet="protein",
     csv=False,
+    parquet=False,
     json_summary=False,
     coding_nucleotide_fasta=None,
     noncoding_nucleotide_fasta=None,
@@ -559,6 +566,8 @@ def cli(
             2. Polar (C, D, E, H, K, N, Q, R, S, T)
     csv : str
         Save the coding scores as a csv to this file
+    parquet : str
+        Save the coding scores as a parquet to this file
     long_reads : bool -- NOT IMPLEMENTED!!
         Input sequencing reads are long reads. Not implemented, but the plan
         is, instead of doing 6-frame translation as on the short reads, test
@@ -590,6 +599,7 @@ def cli(
     assemble_summary_obj = CreateSaveSummary(
         reads,
         csv,
+        parquet,
         json_summary,
         translate_obj.peptide_bloom_filter_filename,
         alphabet,
@@ -597,6 +607,7 @@ def cli(
         translate_obj.jaccard_threshold,
     )
     assemble_summary_obj.maybe_write_csv(coding_scores)
+    assemble_summary_obj.maybe_write_parquet(coding_scores)
     assemble_summary_obj.maybe_write_json_summary(coding_scores)
 
 

--- a/tests/test_create_save_summary.py
+++ b/tests/test_create_save_summary.py
@@ -69,6 +69,17 @@ def true_scores_path(data_folder):
 
 
 @pytest.fixture
+def true_scores_parquet(data_folder):
+    true_scores_parquet = os.path.join(
+        data_folder,
+        "translate",
+        "SRR306838_GSM752691_hsa_br_F_1_trimmed_subsampled_n22__"
+        "alphabet-protein_ksize-7.parquet",
+    )
+    return true_scores_parquet
+
+
+@pytest.fixture
 def single_alphabet_ksize_true_scores(true_scores_path):
     return pd.read_csv(true_scores_path)
 
@@ -78,6 +89,7 @@ def test_maybe_write_json_summary_empty(
 ):
     create_ss = CreateSaveSummary(
         ["nonexistent.fa"],
+        True,
         True,
         True,
         peptide_bloom_filter_path,
@@ -95,6 +107,7 @@ def test_get_n_translated_frames_per_read(
 ):
     create_ss = CreateSaveSummary(
         ["nonexistent.fa"],
+        True,
         True,
         True,
         peptide_bloom_filter_path,
@@ -134,6 +147,7 @@ def test_get_n_per_coding_category(
 
     create_ss = CreateSaveSummary(
         ["nonexistent.fa"],
+        True,
         True,
         True,
         peptide_bloom_filter_path,
@@ -181,7 +195,7 @@ def test_get_n_per_coding_category(
 
 def test_generate_coding_summary(reads, data_folder, single_alphabet_ksize_true_scores):
     create_ss = CreateSaveSummary(
-        reads, True, True, "bloom_filter.nodegraph", "protein", 7, 0.5
+        reads, True, True, True, "bloom_filter.nodegraph", "protein", 7, 0.5
     )
     test_summary = create_ss.generate_coding_summary(single_alphabet_ksize_true_scores)
     print(test_summary)
@@ -232,14 +246,37 @@ def test_generate_coding_summary(reads, data_folder, single_alphabet_ksize_true_
 
 def test_maybe_write_csv(reads, single_alphabet_ksize_true_scores, true_scores_path):
     create_ss = CreateSaveSummary(
-        reads, true_scores_path, True, "bloom_filter.nodegraph", "protein", 7, 0.5
+        reads, true_scores_path, True, True, "bloom_filter.nodegraph", "protein", 7, 0.5
     )
     create_ss.maybe_write_csv(single_alphabet_ksize_true_scores)
 
 
+def test_maybe_write_parquet(
+    reads, single_alphabet_ksize_true_scores, true_scores_parquet
+):
+    create_ss = CreateSaveSummary(
+        reads,
+        True,
+        true_scores_parquet,
+        True,
+        "bloom_filter.nodegraph",
+        "protein",
+        7,
+        0.5,
+    )
+    create_ss.maybe_write_parquet(single_alphabet_ksize_true_scores)
+
+
 def test_make_empty_coding_categories():
     create_ss = CreateSaveSummary(
-        ["nonexistent.fa"], True, True, "bloom_filter.nodegraph", "protein", 7, 0.5
+        ["nonexistent.fa"],
+        True,
+        True,
+        True,
+        "bloom_filter.nodegraph",
+        "protein",
+        7,
+        0.5,
     )
     test_coding_categories = {
         "Translation is shorter than peptide k-mer size + 1": 0,


### PR DESCRIPTION
Coding score CSVs can get quite large! This PR adds the option to output a parquet from `sencha translate` instead. It doesn't explicitly disable csv as an option, so theoretically if desired, a user could output both. 

 I chose to do it this way bc I would prefer to use different file extensions (`.csv`, `.parquet`) for the output, and I think it's a little confusing because the option is explicitly `--csv`. I suppose this could be better handled by using a `--coding-scores` output + `--csv` and `--parquet` flags, but that would break current pipelines.

Closes: #68 

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Ensure the test suite passes with [pytest](https://docs.pytest.org/en/latest/) . (command to run: `pytest` or `make coverage` if you want to see which lines don't have tests yet)
 - [x] Make sure your code is linted and autoformatted using [black](https://github.com/psf/black) (`black . --check`).
 - [x] `README.md` is updated
