### PR TITLE
Remove Biopython dependency

### DIFF
--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,4 +1,3 @@
-biopython
 pytest
 coverage
 click

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
   - attrs=19.3.0=py_0
   - babel=2.8.0=py_0
   - backcall=0.1.0=py_0
-  - biopython=1.74=py37h01d97ff_0
   - bleach=3.1.1=py_0
   - bokeh=1.4.0=py37_0
   - boost-cpp=1.70.0=h75728bb_2

--- a/environment_minimal.yml
+++ b/environment_minimal.yml
@@ -4,7 +4,6 @@ channels:
   - r
   - defaults
 dependencies:
-  - biopython
   - click
   - httmock
   - ipykernel

--- a/environment_no_name.yml
+++ b/environment_no_name.yml
@@ -9,7 +9,6 @@ dependencies:
   - atomicwrites=1.3.0=py_0
   - attrs=19.1.0=py_0
   - backcall=0.1.0=py_0
-  - biopython=1.74=py37h01d97ff_0
   - blas=2.12=openblas
   - bleach=3.1.0=py_0
   - bokeh=1.3.4=py37_0

--- a/environment_no_versions.yml
+++ b/environment_no_versions.yml
@@ -15,7 +15,6 @@ dependencies:
   - attrs
   - babel
   - backcall
-  - biopython
   - bleach
   - bokeh
   - boost-cpp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-biopython
 click
 httmock
 khmer

--- a/requirements_minimal.txt
+++ b/requirements_minimal.txt
@@ -1,4 +1,3 @@
-biopython
 click
 tqdm
 numpy

--- a/requirements_with_versions.txt
+++ b/requirements_with_versions.txt
@@ -1,4 +1,3 @@
-Bio==0.1.0
 click==6.7
 fastcluster==1.1.25
 httmock==1.3.0

--- a/sencha/constants_translate.py
+++ b/sencha/constants_translate.py
@@ -1,5 +1,5 @@
 import itertools
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 
 from sencha.sequence_encodings import ALPHABET_ALIASES
 
@@ -53,3 +53,81 @@ SingleReadScore = namedtuple(
 )
 
 COMPLEXITY_THRESHOLD = 0.3
+
+
+STANDARD_CODON_TABLE_MAPPING = {
+    "ATA": "I",
+    "ATC": "I",
+    "ATT": "I",
+    "ATG": "M",
+    "ACA": "T",
+    "ACC": "T",
+    "ACG": "T",
+    "ACT": "T",
+    "AAC": "N",
+    "AAT": "N",
+    "AAA": "K",
+    "AAG": "K",
+    "AGC": "S",
+    "AGT": "S",
+    "AGA": "R",
+    "AGG": "R",
+    "CTA": "L",
+    "CTC": "L",
+    "CTG": "L",
+    "CTT": "L",
+    "CCA": "P",
+    "CCC": "P",
+    "CCG": "P",
+    "CCT": "P",
+    "CAC": "H",
+    "CAT": "H",
+    "CAA": "Q",
+    "CAG": "Q",
+    "CGA": "R",
+    "CGC": "R",
+    "CGG": "R",
+    "CGT": "R",
+    "GTA": "V",
+    "GTC": "V",
+    "GTG": "V",
+    "GTT": "V",
+    "GCA": "A",
+    "GCC": "A",
+    "GCG": "A",
+    "GCT": "A",
+    "GAC": "D",
+    "GAT": "D",
+    "GAA": "E",
+    "GAG": "E",
+    "GGA": "G",
+    "GGC": "G",
+    "GGG": "G",
+    "GGT": "G",
+    "TCA": "S",
+    "TCC": "S",
+    "TCG": "S",
+    "TCT": "S",
+    "TTC": "F",
+    "TTT": "F",
+    "TTA": "L",
+    "TTG": "L",
+    "TAC": "Y",
+    "TAT": "Y",
+    "TAA": "*",
+    "TAG": "*",
+    "TGC": "C",
+    "TGT": "C",
+    "TGA": "*",
+    "TGG": "W",
+}
+
+STANDARD_CODON_TABLE = defaultdict(lambda: "X")
+STANDARD_CODON_TABLE.update(STANDARD_CODON_TABLE_MAPPING)
+
+REVERSE_COMPLEMENT_MAPPING = {
+    "A": "T",
+    "C": "G",
+    "G": "C",
+    "T": "A",
+}

--- a/sencha/constants_translate.py
+++ b/sencha/constants_translate.py
@@ -64,6 +64,7 @@ STANDARD_CODON_TABLE_MAPPING = {
     "ACC": "T",
     "ACG": "T",
     "ACT": "T",
+    "ACN": "T",
     "AAC": "N",
     "AAT": "N",
     "AAA": "K",
@@ -76,6 +77,7 @@ STANDARD_CODON_TABLE_MAPPING = {
     "CTC": "L",
     "CTG": "L",
     "CTT": "L",
+    "CTN": "L",
     "CCA": "P",
     "CCC": "P",
     "CCG": "P",
@@ -88,14 +90,17 @@ STANDARD_CODON_TABLE_MAPPING = {
     "CGC": "R",
     "CGG": "R",
     "CGT": "R",
+    "CGN": "R",
     "GTA": "V",
     "GTC": "V",
     "GTG": "V",
     "GTT": "V",
+    "GTN": "V",
     "GCA": "A",
     "GCC": "A",
     "GCG": "A",
     "GCT": "A",
+    "GCN": "A",
     "GAC": "D",
     "GAT": "D",
     "GAA": "E",
@@ -104,10 +109,12 @@ STANDARD_CODON_TABLE_MAPPING = {
     "GGC": "G",
     "GGG": "G",
     "GGT": "G",
+    "GGN": "G",
     "TCA": "S",
     "TCC": "S",
     "TCG": "S",
     "TCT": "S",
+    "TCN": "S",
     "TTC": "F",
     "TTT": "F",
     "TTA": "L",
@@ -122,8 +129,6 @@ STANDARD_CODON_TABLE_MAPPING = {
     "TGG": "W",
 }
 
-STANDARD_CODON_TABLE = defaultdict(lambda: "X")
-STANDARD_CODON_TABLE.update(STANDARD_CODON_TABLE_MAPPING)
 
 REVERSE_COMPLEMENT_MAPPING = {
     "A": "T",
@@ -131,3 +136,5 @@ REVERSE_COMPLEMENT_MAPPING = {
     "G": "C",
     "T": "A",
 }
+
+REVERSE_COMPLEMENT_TABLE = str.maketrans("ACGT", "TGCA")

--- a/sencha/translate.py
+++ b/sencha/translate.py
@@ -6,8 +6,7 @@ Partition reads into coding, noncoding, and low-complexity bins
 import sys
 import warnings
 
-from Bio.Seq import Seq
-from Bio import BiopythonWarning
+
 import click
 import numpy as np
 import pandas as pd
@@ -91,14 +90,12 @@ def evaluate_is_kmer_low_complexity(seq, ksize):
     By this definition, the sequence is not complex if its number of unique
     k-mers is smaller than half the number of expected k-mers
     """
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", BiopythonWarning)
-        # Ignore Biopython warning of seq objects being strings now
-        try:
-            kmers = kmerize(seq, ksize)
-        except ValueError:
-            # k-mer size is larger than sequence
-            return None, None
+    # Ignore Biopython warning of seq objects being strings now
+    try:
+        kmers = kmerize(seq, ksize)
+    except ValueError:
+        # k-mer size is larger than sequence
+        return None, None
     n_kmers = len(kmers)
     complexity = compute_kmer_complexity(seq, ksize)
     is_low_complexity = n_kmers <= complexity
@@ -214,7 +211,7 @@ class Translate:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             translations = TranslateSingleSeq(
-                Seq(sequence), self.verbose
+                sequence, self.verbose
             ).six_frame_translation()
         scoring_lines = []
 

--- a/sencha/translate_single_seq.py
+++ b/sencha/translate_single_seq.py
@@ -15,6 +15,7 @@ class TranslateSingleSeq:
         if len(codon) == 3:
             return STANDARD_CODON_TABLE_MAPPING.get(codon, "X")
         else:
+            # only length 3 is a valid codon, return an empty string otherwise
             return ""
 
     def _single_seq_translation(self, seq, frame=0):

--- a/sencha/translate_single_seq.py
+++ b/sencha/translate_single_seq.py
@@ -1,4 +1,7 @@
-import warnings
+from .constants_translate import (
+    STANDARD_CODON_TABLE,
+    REVERSE_COMPLEMENT_MAPPING,
+)
 
 
 class TranslateSingleSeq:
@@ -7,17 +10,27 @@ class TranslateSingleSeq:
         self.verbose = verbose
         self.sign = 1
 
-    def three_frame_translation(self):
-        from Bio import BiopythonWarning
+    @staticmethod
+    def _single_seq_translation(seq, frame=0):
+        return "".join(
+            [
+                STANDARD_CODON_TABLE[seq[(frame + i * 3) : (i * 3 + 3)]]
+                for i in range(int(len(seq) / 3))
+            ]
+        )
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", BiopythonWarning)
-            for frame in range(3):
-                if self.sign == 1:
-                    translation = self.seq[frame:].translate()
-                elif self.sign == -1:
-                    translation = self.seq.reverse_complement()[frame:].translate()
-                yield translation
+    def _reverse_complement(self, seq):
+        return seq.translate(REVERSE_COMPLEMENT_MAPPING)[::-1]
+
+    def three_frame_translation(self):
+
+        for frame in range(3):
+            if self.sign == 1:
+                translation = self._single_seq_translation(self.seq, frame)
+            elif self.sign == -1:
+                reverse_complement = self._reverse_complement(self.seq)
+                translation = self._single_seq_translation(reverse_complement, frame)
+            yield translation
 
     def three_frame_translation_no_stops(self, sign):
         """Remove translations with stop codons &

--- a/sencha/translate_single_seq.py
+++ b/sencha/translate_single_seq.py
@@ -1,6 +1,6 @@
 from .constants_translate import (
-    STANDARD_CODON_TABLE,
-    REVERSE_COMPLEMENT_MAPPING,
+    STANDARD_CODON_TABLE_MAPPING,
+    REVERSE_COMPLEMENT_TABLE,
 )
 
 
@@ -11,16 +11,24 @@ class TranslateSingleSeq:
         self.sign = 1
 
     @staticmethod
-    def _single_seq_translation(seq, frame=0):
-        return "".join(
-            [
-                STANDARD_CODON_TABLE[seq[(frame + i * 3) : (i * 3 + 3)]]
-                for i in range(int(len(seq) / 3))
-            ]
-        )
+    def _translate_codon(codon):
+        if len(codon) == 3:
+            return STANDARD_CODON_TABLE_MAPPING.get(codon, "X")
+        else:
+            return ""
 
-    def _reverse_complement(self, seq):
-        return seq.translate(REVERSE_COMPLEMENT_MAPPING)[::-1]
+    def _single_seq_translation(self, seq, frame=0):
+        translated = ""
+        for i in range(int(len(seq) / 3)):
+            start = frame + (i * 3)
+            end = start + 3
+            codon = seq[start:end]
+            translated += self._translate_codon(codon)
+        return translated
+
+    @staticmethod
+    def _reverse_complement(seq):
+        return seq.translate(REVERSE_COMPLEMENT_TABLE)[::-1]
 
     def three_frame_translation(self):
 
@@ -33,8 +41,7 @@ class TranslateSingleSeq:
             yield translation
 
     def three_frame_translation_no_stops(self, sign):
-        """Remove translations with stop codons &
-        keep track of reading frame"""
+        """Remove translations with stop codons & keep track of reading frame"""
         self.sign = sign
         return {
             self.sign * (i + 1): t
@@ -43,8 +50,7 @@ class TranslateSingleSeq:
         }
 
     def three_frame_translation_stops(self, sign):
-        """Remove translations with stop codons &
-        keep track of reading frame"""
+        """Remove translations with stop codons & keep track of reading frame"""
         self.sign = sign
         return {
             self.sign * (i + 1): t for i, t in enumerate(self.three_frame_translation())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,19 +32,8 @@ def jaccard_threshold(alphabet):
 
 @pytest.fixture
 def seq():
-    from Bio.Seq import Seq
-    from Bio import BiopythonWarning
-
     s = "CGCTTGCTTAATACTGACATCAATAATATTAGGAAAATCGCAATATAACTGTAAATCCTGTTCTGTC"
-    with warnings.catch_warnings():
-        # Ignore The following warning because we don't use Bio.Alphabet
-        # explicitly:
-        # PendingDeprecationWarning: We intend to remove or replace
-        # Bio.Alphabet in 2020, ideally avoid using it explicitly in your
-        # code. Please get in touch if you will be adversely affected by this.
-        # https://github.com/biopython/biopython/issues/2046
-        warnings.simplefilter("ignore", BiopythonWarning)
-        return Seq(s)
+    return s
 
 
 @pytest.fixture

--- a/tests/test_translate_single_seq.py
+++ b/tests/test_translate_single_seq.py
@@ -102,12 +102,3 @@ def test_six_frame_translation_stops(translation):
         -3: "QNRIYSYIAIFLILLMSVLSK",
     }
     assert test == true
-
-
-if __name__ == "__main__":
-    import timeit
-    from Bio import Seq
-
-    timeit.timeit(
-        'TranslateSingleSeq.three_frame_translation(Seq("CGCTTGCTTAATACTGACATCAATAATATTAGGAAAATCGCAATATAACTGTAAATCCTGTTCTGTC"))'
-    )

--- a/tests/test_translate_single_seq.py
+++ b/tests/test_translate_single_seq.py
@@ -13,8 +13,11 @@ def translation(seq):
 
 
 def test__reverse_complement(translation):
-    rev = translation.translate_ss._reverse_complement("AACCGGTT")
-    assert rev == "AACCGGTT"
+    # Palindromic sequence
+    assert translation.translate_ss._reverse_complement("AACCGGTT") == "AACCGGTT"
+
+    # Non-palindrome
+    assert translation.translate_ss._reverse_complement("AACC") == "GGTT"
 
 
 def test__translate_codon(translation):

--- a/tests/test_translate_single_seq.py
+++ b/tests/test_translate_single_seq.py
@@ -12,6 +12,37 @@ def translation(seq):
     return TestTranslateSingleSeq(seq, True)
 
 
+def test__reverse_complement(translation):
+    rev = translation.translate_ss._reverse_complement("AACCGGTT")
+    assert rev == "AACCGGTT"
+
+
+def test__translate_codon(translation):
+    # Make sure first base as "N" results in "X ambiguous amino acid
+    assert translation.translate_ss._translate_codon("NAA") == "X"
+
+    # Threonine can have ambiguous final base
+    assert translation.translate_ss._translate_codon("ACN") == "T"
+
+    # Leucine can have an ambiguous final base
+    assert translation.translate_ss._translate_codon("CTN") == "L"
+
+    # Valine can have ambiguous final base
+    assert translation.translate_ss._translate_codon("GTN") == "V"
+
+    # Alanine can have ambiguous final base
+    assert translation.translate_ss._translate_codon("GCN") == "A"
+
+    # Arginine can have ambiguous final base
+    assert translation.translate_ss._translate_codon("CGN") == "R"
+
+    # Glycine can have ambiguous final base
+    assert translation.translate_ss._translate_codon("GGN") == "G"
+
+    # Make sure too short codons don't translate
+    assert translation.translate_ss._translate_codon("AC") == ""
+
+
 def test_three_frame_translation(translation):
     test = [str(x) for x in translation.translate_ss.three_frame_translation()]
     true = ["RLLNTDINNIRKIAI*L*ILFC", "ACLILTSIILGKSQYNCKSCSV", "LA*Y*HQ*Y*ENRNITVNPVL"]
@@ -68,3 +99,12 @@ def test_six_frame_translation_stops(translation):
         -3: "QNRIYSYIAIFLILLMSVLSK",
     }
     assert test == true
+
+
+if __name__ == "__main__":
+    import timeit
+    from Bio import Seq
+
+    timeit.timeit(
+        'TranslateSingleSeq.three_frame_translation(Seq("CGCTTGCTTAATACTGACATCAATAATATTAGGAAAATCGCAATATAACTGTAAATCCTGTTCTGTC"))'
+    )


### PR DESCRIPTION
This PR removes the biopython dependency because a lot of time is spent converting between Python strings and Biopython `Seq` objects and back, which makes `sencha translate` take forever

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Ensure the test suite passes with [pytest](https://docs.pytest.org/en/latest/) . (command to run: `pytest` or `make coverage` if you want to see which lines don't have tests yet)
 - [ ] Make sure your code is linted and autoformatted using [black](https://github.com/psf/black) (`black . --check`).
 - [ ] Documentation in `usage.md` is updated
 - [ ] `README.md` is updated
